### PR TITLE
ODP-1476: Ranger Ozone service test connection failing with NoSuchMethodError

### DIFF
--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -149,6 +149,9 @@
                     <include>com.github.joshelser.**.*</include>
                     <include>com.twitter.**.*</include>
                   </includes>
+                  <excludes>
+                    <exclude>com.google.common.cache.**.*</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>kotlin</pattern>


### PR DESCRIPTION
Ranger Ozone service test connection failing with NoSuchMethodError on ODP 3.2.3.1-2


```
java.lang.NoSuchMethodError: org.apache.hadoop.util.CacheMetrics.create(Lcom/google/common/cache/Cache;Ljava/lang/Object;)Lorg/apache/hadoop/util/CacheMetrics;
``` 

/usr/odp/3.2.3.1-2/ranger-admin/ews/webapp/WEB-INF/classes/ranger-plugins/ozone/ has two jars with this class and method. Seems like ozone-filesystem.jar is being picked up instead of hdds-commons.jar