### PR TITLE
ODP-2723 | ODP-4102 - Eliminating Cyclic Dependency && Fixing Ozone Compilation Issue

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
@@ -123,7 +123,7 @@ public class HttpFSServerWebServer {
         .setName(NAME)
         .setConf(conf)
         .setSSLConf(sslConf)
-        .authFilterConfigurationPrefix(HttpFSAuthenticationFilter.CONF_PREFIX)
+        .setAuthFilterConfigurationPrefix(HttpFSAuthenticationFilter.CONF_PREFIX)
         .setACL(new AccessControlList(conf.get(HTTP_ADMINS_KEY, " ")))
         .addEndpoint(endpoint)
         .build();

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -53,6 +53,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-manager</artifactId>
+        <exclusions>
+         <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>jmespath-java</artifactId>
+         </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -80,6 +80,11 @@
         <artifactId>ozone-interface-client</artifactId>
         <version>${ozone.version}</version>
       </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
         <artifactId>ozone-interface-storage</artifactId>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -32,6 +32,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-manager</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>jmespath-java</artifactId>
+        </exclusion>
+       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>


### PR DESCRIPTION
Ozone was failing with the following compilation failure.
Here is the compilation failure.
```

[INFO] ------------------------------------------------------------------------
[INFO] 736 goals, 700 executed, 36 from cache, saving at least 1m 6s
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project ozone-httpfsgateway: Compilation failure
[ERROR] /root/ozone/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java:[126,9] cannot find symbol
[ERROR]   symbol:   method authFilterConfigurationPrefix(java.lang.String)
[ERROR]   location: class org.apache.hadoop.http.HttpServer2.Builder
```
RCA suggests that it was due to this change 
[ODP-2997: HADOOP-18666|HADOOP-13129 :A whitelist of endpoints to skip… · acceldata-io/hadoop@ede35b7](https://github.com/acceldata-io/hadoop/commit/ede35b755e810cbdd12f9eb89582f6612907160f) 

We need to update the reference(s) in Ozone to use the new method name now.
