### PR TITLE
[WIP] OSV-10672|OSV-10666 Update Hadoop-thirdparty and associated jar to match with ODP stack Hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- ProtocolBuffer version, used to verify the protoc version and -->
     <!-- define the protobuf JAR version                               -->
     <proto2.hadooprpc.protobuf.version>2.5.0</proto2.hadooprpc.protobuf.version>
-    <proto3.hadooprpc.protobuf.version>3.7.1</proto3.hadooprpc.protobuf.version>
-    <hadoop-thirdparty.version>1.1.1</hadoop-thirdparty.version>
+    <proto3.hadooprpc.protobuf.version>3.25.5</proto3.hadooprpc.protobuf.version>
+    <hadoop-thirdparty.version>1.4.0</hadoop-thirdparty.version>
 
     <findbugs.version>3.0.0</findbugs.version>
     <spotbugs.version>3.1.12</spotbugs.version>
-    <dnsjava.version>2.1.7</dnsjava.version>
+    <dnsjava.version>3.6.0</dnsjava.version>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <stax2.version>4.2.2</stax2.version>
@@ -230,7 +230,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <compile-testing.version>0.19</compile-testing.version>
     <errorprone-annotations.version>2.2.0</errorprone-annotations.version>
-    <guava.version>32.0.0-jre</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <gson.version>2.9.0</gson.version>
 
@@ -1355,7 +1355,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop.thirdparty</groupId>
-        <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+        <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
         <version>${hadoop-thirdparty.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
OSV-10672|OSV-10666 Update Hadoop-thirdparty and associated jar to match with ODP stack Hadoop
This change addresses multiple CVEs in ozone being packaged in the older version of protobuf and dns-java.

Note: dns-java 3.6.0 is JDK11+ while ODP 3.2.3.6-2 is expected to be JDK8/11 compatible.