### PR TITLE
[OSV-18758] Bump grpc.protobuf-compile.version to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
-    <grpc.protobuf-compile.version>3.19.6</grpc.protobuf-compile.version>
+    <grpc.protobuf-compile.version>3.25.5</grpc.protobuf-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
     <!-- Use netty version known to work with grpc-netty. See table: -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump grpc.protobuf-compile.version to 3.25.5 to fix CVE-2024-7254

Reference JIRA for version bump from upstream: https://issues.apache.org/jira/browse/HDDS-7289
Ratis and ratis-thirdparty must also use same proto version. Our current ratis and ratis-thirdparty is already using protobuf-3.25.5.
Upstream reference PR: https://github.com/apache/ozone/pull/4003/changes

## What is the link to the Apache JIRA

[OSV-18758](https://accelcentral.atlassian.net/browse/OSV-18758)


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)


[OSV-18758]: https://accelcentral.atlassian.net/browse/OSV-18758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ