### PR TITLE
OSV-22071: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Use netty version known to work with grpc-netty. See table: -->
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <io.grpc.version>1.60.0</io.grpc.version>
 
     <rocksdb.version>7.7.3</rocksdb.version>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (17)
OSV-22071, OSV-22072, OSV-22080, OSV-22085, OSV-22086, OSV-22087, OSV-22088, OSV-22089, OSV-22090, OSV-22091, OSV-22092, OSV-22093, OSV-22120, OSV-22121, OSV-22122, OSV-22124, OSV-22125
