### PR TITLE
OSV-22144 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- jackson versions -->
     <jackson1.version>1.9.13</jackson1.version>
     <jackson-jaxr.version>1.9.13</jackson-jaxr.version>
-    <jackson2-bom.version>2.16.1</jackson2-bom.version>
+    <jackson2-bom.version>2.18.6</jackson2-bom.version>
     <woodstox.version>5.4.0</woodstox.version>
 
     <!-- jaegertracing veresion -->


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-22144, OSV-23528