### PR TITLE
OSV-23532 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2025-68161

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
   </modules>
 
   <properties>
-    <odp.release.version>3.3.6.5-SNAPSHOT</odp.release.version>
     <activation-api.version>1.2.2</activation-api.version>
     <annotation-api.version>1.3.2</annotation-api.version>
     <aopalliance.version>1.0</aopalliance.version>
@@ -143,7 +142,7 @@
     <kerby.version>1.0.1</kerby.version>
     <kotlin.version>1.9.25</kotlin.version>
     <license-maven-plugin.version>2.7.0</license-maven-plugin.version>
-    <log4j2.version>2.25.0</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
@@ -180,6 +179,7 @@
     <netty.version>4.1.119.Final</netty.version>
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>16.14.2</nodejs.version>
+    <odp.release.version>3.3.6.5-SNAPSHOT</odp.release.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <opentelemetry.version>1.54.1</opentelemetry.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-23532, OSV-23533, OSV-23534, OSV-23535, OSV-23536, OSV-23537