### PR TITLE
OSV-22074 - CVE - Bumped-up Spring Framework to 5.3.39 to address CVE-2024-38808

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <awaitility.version>4.2.0</awaitility.version>
     <jgrapht.version>1.4.0</jgrapht.version>
 
-    <spring.version>5.3.34</spring.version>
+    <spring.version>5.3.39</spring.version>
     <jooq.version>3.11.10</jooq.version>
 
     <vault.driver.version>5.1.0</vault.driver.version>


### PR DESCRIPTION
- Component: ozone (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Spring Framework → 5.3.39
- Tickets: OSV-22074
- Files: pom.xml