### PR TITLE
OSV-22146 - CVE - Bumped-up Netty to 4.1.133.Final to address CVE-2026-42578

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Use netty version known to work with grpc-netty. See table: -->
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.version>4.1.111.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <io.grpc.version>1.60.0</io.grpc.version>
 
     <rocksdb.version>7.7.3</rocksdb.version>


### PR DESCRIPTION
- Component: ozone (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Netty → 4.1.133.Final
- Tickets: OSV-22146
- Files: pom.xml