### PR TITLE
OSV-23526 - CVE - Bumped-up commons-configuration2 to 2.15.0 to address CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <commons-codec.version>1.18.0</commons-codec.version>
     <commons-collections.version>4.4</commons-collections.version>
     <commons-compress.version>1.27.1</commons-compress.version>
-    <commons-configuration2.version>2.12.0</commons-configuration2.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <commons-daemon.version>1.4.0</commons-daemon.version>
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
     <commons-io.version>2.18.0</commons-io.version>


### PR DESCRIPTION
- Component: ozone2 (nightly/ODP-2.1.0.3.3.6.5, release 3.3.6.4)
- Library: commons-configuration2 → 2.15.0
- Tickets: OSV-23526
- Files: pom.xml