### PR TITLE
OSV-23527 - CVE - Bumped-up OpenTelemetry to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <nodejs.version>16.14.2</nodejs.version>
     <odp.release.version>3.3.6.5-SNAPSHOT</odp.release.version>
     <okhttp3.version>4.12.0</okhttp3.version>
-    <opentelemetry.version>1.54.1</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <ozone.release>Joshua Tree</ozone.release>
     <ozone.version>2.1.0.${odp.release.version}</ozone.version>


### PR DESCRIPTION
- Component: ozone2 (nightly/ODP-2.1.0.3.3.6.5, release 3.3.6.4)
- Library: OpenTelemetry → 1.62.0
- Tickets: OSV-23527
- Files: pom.xml